### PR TITLE
fix(webdriverio): use string as return type in "url" command

### DIFF
--- a/packages/webdriverio/src/commands/browser/url.ts
+++ b/packages/webdriverio/src/commands/browser/url.ts
@@ -112,7 +112,7 @@ export async function url (
     this: WebdriverIO.Browser,
     path: string,
     options: UrlCommandOptions = {}
-): Promise<WebdriverIO.Request | void> {
+): Promise<WebdriverIO.Request | string | void> {
     if (typeof path !== 'string') {
         throw new Error('Parameter for "url" command needs to be type of string')
     }


### PR DESCRIPTION
Temporary hack in order to correctly work with testplane@8