### PR TITLE
fix: support devtools correctly with wdio

### DIFF
--- a/packages/webdriverio/src/commands/browser/execute.ts
+++ b/packages/webdriverio/src/commands/browser/execute.ts
@@ -78,9 +78,11 @@ export async function execute<ReturnValue, InnerArguments extends unknown[]> (
      */
     if (typeof script === 'function') {
         script = `
-            ${polyfillFn}
-            webdriverioPolyfill()
-            return (${script}).apply(null, arguments)
+            return (function () {
+                ${polyfillFn}
+                webdriverioPolyfill()
+                return (${script}).apply(null, arguments)
+            }).apply(null, arguments)
         `
     }
 

--- a/packages/webdriverio/src/commands/browser/executeAsync.ts
+++ b/packages/webdriverio/src/commands/browser/executeAsync.ts
@@ -103,9 +103,11 @@ export async function executeAsync<ReturnValue, InnerArguments extends unknown[]
      */
     if (typeof script === 'function') {
         script = `
-            ${polyfillFn}
-            webdriverioPolyfill()
-            return (${script}).apply(null, arguments)
+            return (function () {
+                ${polyfillFn}
+                webdriverioPolyfill()
+                return (${script}).apply(null, arguments)
+            }).apply(null, arguments)
         `
     }
 

--- a/packages/webdriverio/src/constants.ts
+++ b/packages/webdriverio/src/constants.ts
@@ -42,26 +42,28 @@ export const WDIO_DEFAULTS: Options.Definition<Capabilities.WebdriverIOConfig> =
                 return
             }
 
+            const packageName = param === SupportedAutomationProtocols.stub ? param : `@testplane/${param}`
+
             try {
-                import.meta.resolve(param)
+                import.meta.resolve(packageName)
             } catch (err) {
                 const error = err instanceof Error ? err : new Error('unknown error')
-                throw new Error(`Couldn't find automation protocol "${param}": ${error.message}`)
+                throw new Error(`Couldn't find automation protocol "${packageName}": ${error.message}`)
             }
 
             try {
                 const __dirname = dirname(fileURLToPath(import.meta.url))
                 const require = createRequire(import.meta.url)
-                const id = param === SupportedAutomationProtocols.stub
-                    ? resolve(__dirname, '..', 'build', param)
-                    : param
+                const id = packageName === SupportedAutomationProtocols.stub
+                    ? resolve(__dirname, '..', 'build', packageName)
+                    : packageName
                 require.resolve(id)
             // eslint-disable-next-line @typescript-eslint/no-unused-vars, @typescript-eslint/no-explicit-any
             } catch (err: any) {
                 /* istanbul ignore next */
                 throw new Error(
                     'Automation protocol package is not installed!\n' +
-                    `Please install it via \`npm install ${param}\``
+                    `Please install it via \`npm install ${packageName}\``
                 )
             }
         }

--- a/packages/webdriverio/src/constants.ts
+++ b/packages/webdriverio/src/constants.ts
@@ -24,6 +24,13 @@ export const WDIO_DEFAULTS: Options.Definition<Capabilities.WebdriverIOConfig> =
             /**
              * path when proxy is used for browser testing
              */
+            if (param.endsWith('driver.js')) {
+                return
+            }
+
+            /**
+             * path when proxy is used for browser testing
+             */
             if (typeof param !== 'string') {
                 throw new Error('automationProtocol should be a string')
             }

--- a/packages/webdriverio/src/utils/driver.ts
+++ b/packages/webdriverio/src/utils/driver.ts
@@ -46,7 +46,8 @@ export async function getProtocolDriver (options: Capabilities.WebdriverIOConfig
      */
     if (automationProtocol === SupportedAutomationProtocols.devtools || automationProtocol?.startsWith('/@fs/')) {
         try {
-            const DevTools = await import(`@testplane/${automationProtocol}`)
+            const packageName = automationProtocol === 'devtools' ? `@testplane/${automationProtocol}` : automationProtocol
+            const DevTools = await import(packageName)
             log.info('Starting session using Chrome DevTools as automation protocol and Puppeteer as driver')
             return { Driver: DevTools.default, options }
         } catch (err: unknown) {


### PR DESCRIPTION
- support "driver.js" protocol for component testing
- send execute commands with wrapper in order to correctly work with devtools