### PR TITLE
fix: correctly specify return types chainable commands

### DIFF
--- a/packages/wdio-browser-runner/src/browser/expect.ts
+++ b/packages/wdio-browser-runner/src/browser/expect.ts
@@ -32,7 +32,7 @@ const COMMAND_TIMEOUT = 30 * 1000 // 30s
  */
 function createMatcher (matcherName: string) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return async function (this: MatcherContext, context: WebdriverIO.Browser | WebdriverIO.Element | ChainablePromiseElement | ChainablePromiseArray, ...args: any[]) {
+    return async function (this: MatcherContext, context: WebdriverIO.Browser | WebdriverIO.Element | ChainablePromiseElement<WebdriverIO.Element> | ChainablePromiseArray, ...args: any[]) {
         const cid = getCID()
         if (!import.meta.hot || !cid) {
             return {

--- a/packages/webdriverio/src/commands/browser/switchFrame.ts
+++ b/packages/webdriverio/src/commands/browser/switchFrame.ts
@@ -67,9 +67,9 @@ const log = logger('webdriverio:switchFrame')
  */
 export async function switchFrame (
     this: WebdriverIO.Browser,
-    context: WebdriverIO.Element | ChainablePromiseElement | string | null | ((tree: FlatContextTree) => boolean | Promise<boolean>)
+    context: WebdriverIO.Element | ChainablePromiseElement<WebdriverIO.Element> | string | null | ((tree: FlatContextTree) => boolean | Promise<boolean>)
 ) {
-    function isPossiblyUnresolvedElement(input: typeof context): input is WebdriverIO.Element | ChainablePromiseElement {
+    function isPossiblyUnresolvedElement(input: typeof context): input is WebdriverIO.Element | ChainablePromiseElement<WebdriverIO.Element> {
         return Boolean(input) && typeof input === 'object' && typeof (input as WebdriverIO.Element).getElement === 'function'
     }
 

--- a/packages/webdriverio/src/commands/element/dragAndDrop.ts
+++ b/packages/webdriverio/src/commands/element/dragAndDrop.ts
@@ -38,7 +38,7 @@ const sleep = (time = 0) => new Promise((resolve) => setTimeout(resolve, time))
  */
 export async function dragAndDrop (
     this: WebdriverIO.Element,
-    target: WebdriverIO.Element | ChainablePromiseElement | Partial<DragAndDropCoordinate>,
+    target: WebdriverIO.Element | ChainablePromiseElement<WebdriverIO.Element> | Partial<DragAndDropCoordinate>,
     options: DragAndDropOptions = {}
 ) {
     const moveToCoordinates = target as DragAndDropCoordinate

--- a/packages/webdriverio/src/commands/element/getElement.ts
+++ b/packages/webdriverio/src/commands/element/getElement.ts
@@ -17,6 +17,6 @@ import type { ChainablePromiseElement } from '../../types.js'
  * @type utility
  *
  */
-export async function getElement (this: WebdriverIO.Element | ChainablePromiseElement): Promise<WebdriverIO.Element> {
+export async function getElement (this: WebdriverIO.Element | ChainablePromiseElement<WebdriverIO.Element>): Promise<WebdriverIO.Element> {
     return this as WebdriverIO.Element
 }

--- a/packages/webdriverio/src/commands/element/getElements.ts
+++ b/packages/webdriverio/src/commands/element/getElements.ts
@@ -17,6 +17,6 @@ import type { ChainablePromiseArray } from '../../types.js'
  * @type utility
  *
  */
-export async function getElements (this: WebdriverIO.ElementArray | ChainablePromiseArray): Promise<WebdriverIO.ElementArray> {
+export async function getElements (this: WebdriverIO.ElementArray | ChainablePromiseArray<WebdriverIO.Element>): Promise<WebdriverIO.ElementArray> {
     return this as WebdriverIO.ElementArray
 }

--- a/packages/webdriverio/src/commands/element/scrollIntoView.ts
+++ b/packages/webdriverio/src/commands/element/scrollIntoView.ts
@@ -146,7 +146,7 @@ type MobileScrollUntilVisibleOptions = {
     element: WebdriverIO.Element;
     maxScrolls: number;
     direction: `${MobileScrollDirection}`;
-    scrollableElement?: WebdriverIO.Element | ChainablePromiseElement | null;
+    scrollableElement?: WebdriverIO.Element | ChainablePromiseElement<WebdriverIO.Element> | null;
     duration?: number;
     percent?: number;
 };

--- a/packages/webdriverio/src/commands/mobile/swipe.ts
+++ b/packages/webdriverio/src/commands/mobile/swipe.ts
@@ -108,7 +108,7 @@ async function calculateFromTo({
     browser: WebdriverIO.Browser,
     direction: `${MobileScrollDirection}`,
     percentage?: number,
-    scrollableElement: WebdriverIO.Element | ChainablePromiseElement
+    scrollableElement: WebdriverIO.Element | ChainablePromiseElement<WebdriverIO.Element>
     }): Promise<{ from: XY, to: XY }> {
     // 1. Determine the percentage of the scrollable container to be scrolled
     // The swipe percentage is the percentage of the scrollable container that should be scrolled

--- a/packages/webdriverio/src/types.ts
+++ b/packages/webdriverio/src/types.ts
@@ -33,9 +33,9 @@ type $ElementCommands = typeof ElementCommands
 type ElementQueryCommands = '$' | 'custom$' | 'shadow$' | 'react$'
 type ElementsQueryCommands = '$$' | 'custom$$' | 'shadow$$' | 'react$$'
 type ChainablePrototype = {
-    [K in ElementQueryCommands]: (...args: Parameters<$ElementCommands[K]>) => ChainablePromiseElement
+    [K in ElementQueryCommands]: (...args: Parameters<$ElementCommands[K]>) => ChainablePromiseElement<ThenArg<ReturnType<$ElementCommands[K]>>>
 } & {
-    [K in ElementsQueryCommands]: (...args: Parameters<$ElementCommands[K]>) => ChainablePromiseArray
+    [K in ElementsQueryCommands]: (...args: Parameters<$ElementCommands[K]>) => ChainablePromiseArray<ThenArg<ReturnType<$ElementCommands[K]>>>
 }
 
 type AsyncElementProto = {
@@ -71,9 +71,10 @@ interface ChainablePromiseBaseElement {
      */
     getElement(): Promise<WebdriverIO.Element>
 }
-export interface ChainablePromiseElement extends
+export interface ChainablePromiseElement<T> extends
     ChainablePromiseBaseElement,
     AsyncElementProto,
+    Promise<T>,
     Omit<WebdriverIO.Element, keyof ChainablePromiseBaseElement | keyof AsyncElementProto> {}
 
 interface AsyncIterators<T> {
@@ -98,7 +99,7 @@ interface AsyncIterators<T> {
     entries(): AsyncIterableIterator<[number, WebdriverIO.Element]>;
 }
 
-export interface ChainablePromiseArray extends AsyncIterators<WebdriverIO.Element> {
+export interface ChainablePromiseArray<T> extends Promise<T>, AsyncIterators<T> {
     [Symbol.asyncIterator](): AsyncIterableIterator<WebdriverIO.Element>
     [Symbol.iterator](): IterableIterator<WebdriverIO.Element>
 
@@ -120,7 +121,7 @@ export interface ChainablePromiseArray extends AsyncIterators<WebdriverIO.Elemen
     /**
      * allow to access a specific index of the element set
      */
-    [n: number]: ChainablePromiseElement
+    [n: number]: ChainablePromiseElement<WebdriverIO.Element | undefined>
     /**
      * get the `WebdriverIO.Element[]` list
      */
@@ -550,7 +551,7 @@ export type SwipeOptions = {
     duration?: number;
     from?: XY;
     percent?: number;
-    scrollableElement?: WebdriverIO.Element | ChainablePromiseElement ;
+    scrollableElement?: WebdriverIO.Element | ChainablePromiseElement<WebdriverIO.Element> ;
     to?: XY;
 }
 

--- a/packages/webdriverio/src/utils/actions/pointer.ts
+++ b/packages/webdriverio/src/utils/actions/pointer.ts
@@ -41,7 +41,7 @@ const MOVE_PARAM_DEFAULTS = {
     x: 0,
     y: 0,
     duration: 100,
-    origin: ORIGIN_DEFAULT as (Origin | ElementReference | ChainablePromiseElement | WebdriverIO.Element)
+    origin: ORIGIN_DEFAULT as (Origin | ElementReference | ChainablePromiseElement<WebdriverIO.Element> | WebdriverIO.Element)
 }
 
 type PointerActionParams = Partial<typeof PARAM_DEFAULTS> & Partial<PointerActionUpParams>

--- a/packages/webdriverio/src/utils/actions/wheel.ts
+++ b/packages/webdriverio/src/utils/actions/wheel.ts
@@ -22,7 +22,7 @@ export interface ScrollParams {
     /**
      * element origin
      */
-    origin?: WebdriverIO.Element | ChainablePromiseElement
+    origin?: WebdriverIO.Element | ChainablePromiseElement<WebdriverIO.Element>
     /**
      * duration ratio be the ratio of time delta and duration
      */


### PR DESCRIPTION
## Proposed changes

When calling commands `$` and `$$` with await in front of them typescript show warning - `'await' has no effect on the type of this expression`. In this PR I return behaviour which was in wdio@8