### PR TITLE
fix: do not retry errors with code timeout from webdriver

### DIFF
--- a/packages/webdriver/src/request/index.ts
+++ b/packages/webdriver/src/request/index.ts
@@ -287,6 +287,17 @@ export default abstract class WebDriverRequest extends EventEmitter {
             throw error
         }
 
+        /**
+         * W3C `timeout` (e.g. page load timeout) means the driver already enforced the
+         * configured timeout. Retrying would spend more time than was configured, so terminate immediately.
+         */
+        if (error.name === 'timeout') {
+            log.debug('Request timed out on the driver side - terminating request without retry')
+            this.emit('response', { error })
+            this.emit('performance', { request: fullRequestOptions, durationMillisecond, success: false, error, retryCount })
+            throw error
+        }
+
         return retry(error, `Request failed with status ${response.statusCode} due to ${error.message}`)
     }
 }


### PR DESCRIPTION
### What's done?

Added a check to NOT retry errors with code timeout from driver.

Motivation:
1. User sets page load timeout=2s
2. Makes a request to a page that loads indefinitely
3. We do 1 + 3 tries under the hood, resulting in 8s spent on this command instead of 2s the user declared

What `timeout` code means is described in the spec: https://w3c.github.io/webdriver/#dfn-timeout

In practice, we are interested in this for navigation commands, timeouts related to: script execution, timeouts to the driver itself, etc. are not affected by this change.

My change disables timeouts specifically for a case when a driver returns the `timeout` code, signaling it failed to complete requested operation on time.

Tested on: chrome 138, firefox 145, safari 26.