### PR TITLE
fix: add an option to disable auto-retrying of cancelled request

### DIFF
--- a/packages/webdriverio/src/commands/browser/url.ts
+++ b/packages/webdriverio/src/commands/browser/url.ts
@@ -216,6 +216,10 @@ export async function url (
             url: path,
             wait
         }).catch((err) => {
+            if (options._noFallbackOnCancel) {
+                throw err
+            }
+
             /**
              * It seems that WebDriver Bidi runs into issue with concurrent navigation.
              * @see https://github.com/w3c/webdriver-bidi/issues/878
@@ -326,4 +330,18 @@ interface UrlCommandOptions {
      * Checkout `browser.addPreloadScript` for a more versatile way to mock the environment.
      */
     onBeforeLoad?: () => unknown
+    /**
+     * @internal
+     *
+     * UNSTABLE / INTERNAL — not part of the public API. May be renamed or removed at any time
+     * without notice and without a major version bump. Do not rely on this in user code.
+     *
+     * Used internally to disable the automatic fallback that re-issues the navigation when the
+     * driver reports a concurrent-navigation error (Chrome: "navigation canceled by concurrent
+     * navigation", Firefox: "failed with error: unknown error"). Intended for callers that
+     * intentionally cancelled the navigation and want the original error to propagate.
+     *
+     * @default false
+     */
+    _noFallbackOnCancel?: boolean
 }


### PR DESCRIPTION
### What's done?

- Added an option that's intended to be used internally by testplane to disable after-retrying of cancelled requests in bidi

Motivation:
1. User uses BiDi and uses `openAndWait` command to open a page that hangs indefinitely with timeout 5s
2. When bidi is used, driver doesn't respect the page load timeout
3. So to enforce specified timeout, we send another concurrent request `browser.url('about:blank')`, which cancels hanging navigation.
4. webdriverio catches this error and tries once again, the request eventually takes 10s instead of 5.

This PR adds a way to control this kind of retries.