### PR TITLE
fix(webdriver): do not retry timeouts for "response" event

### DIFF
--- a/packages/webdriver/src/request/index.ts
+++ b/packages/webdriver/src/request/index.ts
@@ -27,6 +27,7 @@ export class RequestLibError extends Error {
     statusCode?: number
     body?: unknown
     code?: string
+    event?: string
 }
 
 export const COMMANDS_WITHOUT_RETRY = [
@@ -218,6 +219,13 @@ export default abstract class WebDriverRequest extends EventEmitter {
              */
             if ((response as RequestLibError).code === 'ETIMEDOUT') {
                 const error = getTimeoutError(response, fullRequestOptions)
+
+                if ((response as RequestLibError).event === 'response') {
+                    log.debug('Request timed out waiting for server response - not retrying')
+                    this.emit('response', { error })
+                    this.emit('performance', { request: fullRequestOptions, durationMillisecond, success: false, error, retryCount })
+                    throw error
+                }
 
                 return retry(error, 'Request timed out! Consider increasing the "connectionRetryTimeout" option.')
             }


### PR DESCRIPTION
### What's done?

Added a check to NOT retry errors when response timed out. 

Motivation:

1. It makes no sense to retry the request when the connection to the server (appium for example) has been established, but the response has not been received during the timeout. In most cases, this means that the session has crashed.
2. other problems with network are stille retried (events like: `connect`, `lookup` (dns), etc...)
