### PR TITLE
fix: fix issues that made webdriverio incompatible with IE

### DIFF
--- a/packages/webdriver/package.json
+++ b/packages/webdriver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@testplane/webdriver",
-  "version": "9.5.17",
+  "version": "9.5.18",
   "description": "A Node.js bindings implementation for the W3C WebDriver and Mobile JSONWire Protocol",
   "author": "Christian Bromann <mail@bromann.dev>",
   "homepage": "https://github.com/webdriverio/webdriverio/tree/main/packages/webdriver",

--- a/packages/webdriver/src/utils.ts
+++ b/packages/webdriver/src/utils.ts
@@ -69,7 +69,8 @@ export async function startWebDriverSession (params: RemoteConfig): Promise<{ se
          * or user requests a Safari session which does not support Bidi
          */
         typeof w3cCaps.alwaysMatch.browserName === 'string' &&
-        w3cCaps.alwaysMatch.browserName.toLowerCase() !== 'safari'
+        w3cCaps.alwaysMatch.browserName.toLowerCase() !== 'safari' &&
+        w3cCaps.alwaysMatch.browserName.toLowerCase() !== 'internet explorer'
     ) {
         /**
          * opt-into WebDriver Bidi

--- a/packages/webdriverio/package.json
+++ b/packages/webdriverio/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@testplane/webdriverio",
   "description": "Next-gen browser and mobile automation test framework for Node.js",
-  "version": "9.5.28",
+  "version": "9.5.29",
   "homepage": "https://webdriver.io",
   "author": "Christian Bromann <mail@bromann.dev>",
   "license": "MIT",

--- a/packages/webdriverio/src/session/polyfill.ts
+++ b/packages/webdriverio/src/session/polyfill.ts
@@ -10,6 +10,10 @@ export function getPolyfillManager(browser: WebdriverIO.Browser) {
 
 const log = logger('webdriverio:PolyfillManager')
 
+type WebdriverioPolyfillGlobal = {
+    __name: (target: unknown, fnName: unknown) => unknown
+}
+
 /**
  * A polyfill to set `__name` to the global scope which is needed for WebdriverIO to properly
  * execute custom (preload) scripts. When using `tsx` Esbuild runs some optimizations which
@@ -19,13 +23,12 @@ const log = logger('webdriverio:PolyfillManager')
  * @see https://github.com/evanw/esbuild/issues/2605
  */
 export const polyfillFn = function webdriverioPolyfill () {
-    const __defProp = Object.defineProperty
-    const __name = function (target: unknown, value: unknown) {
-        return __defProp(target, 'name', { value: value, configurable: true })
+    ;(
+        ((typeof globalThis === 'object' && globalThis) ||
+            (typeof window === 'object' && window)) as unknown as WebdriverioPolyfillGlobal
+    ).__name = function (target: unknown, fnName: unknown) {
+        return Object.defineProperty(target, 'name', { value: fnName, configurable: true })
     }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const __globalThis = (typeof globalThis === 'object' && globalThis) || (typeof window === 'object' && window) as any
-    __globalThis.__name = __name
 }
 
 /**

--- a/packages/webdriverio/tests/session/polyfill.test.ts
+++ b/packages/webdriverio/tests/session/polyfill.test.ts
@@ -2,7 +2,7 @@
 import path from 'node:path'
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest'
 
-import { PolyfillManager } from '../../src/session/polyfill.js'
+import { PolyfillManager, polyfillFn } from '../../src/session/polyfill.js'
 import {
     // @ts-expect-error mock
     instances,
@@ -55,6 +55,10 @@ describe('PolyfillManager', () => {
         expect(browser.browsingContextGetTree).toBeCalledTimes(0)
         expect(instances[0].name).toBe('PolyfillManager')
         expect(await manager.initialize()).toBe(true)
+    })
+
+    it('should serialize the polyfill with legacy-compatible syntax', () => {
+        expect(polyfillFn.toString()).not.toMatch(/\b(?:const|let)\b|=>|\{\s*value\s*,/)
     })
 
     it('should register all eventhandlers and scripts', async () => {


### PR DESCRIPTION
### What's done?

- Do not enable BiDi for IE automatically
- Fix wdio polyfill syntax to work in IE